### PR TITLE
Maintanance (Fix CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on: # trigger this workflow on
     paths-ignore:
       - 'README.org'
       - 'CONTRIBUTING.org'
-  pull_request: # or every pull request, from any branch to any branch
+  pull_request_target: # or every pull request, from any branch to any branch
     paths-ignore:
       - 'README.org'
       - 'CONTRIBUTING.org'
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/README.org
+++ b/README.org
@@ -144,7 +144,7 @@ answer all the questions.
 
     actions/checkout@v3.2.0,
     cachix/cachix-action@v12,
-    cachix/install-nix-action@v18,
+    cachix/install-nix-action@v20,
     actions/setup-python@v4,
 
     #+end_src

--- a/README.org
+++ b/README.org
@@ -27,19 +27,13 @@ answer all the questions.
 
     (use-package erk) ; vanilla
 
-    ;; using elpaca
-    (elpaca-use-package
-     (erk :host github
-          :repo "positron-solutions/elisp-repo-kit"))
-
-    ;; straight without `straight-use-package-by-default'
-    (straight-use-package '(erk :type git :host github
-                                :repo "positron-solutions/elisp-repo-kit"))
-
-    ;; straight with `straight-use-package-by-default' t
+    ;; using elpaca's with explicit recipe
     (use-package erk
-      :straight
-      (erk :type git :host github :repo "positron-solutions/elisp-repo-kit"))
+      :elpaca (erk :host github :repo "positron-solutions/elisp-repo-kit"))
+
+    ;; straight with explicit recipe
+    (use-package erk
+      :straight (erk :type git :host github :repo "positron-solutions/elisp-repo-kit"))
 
     ;; or use melpa, manual load-path & require, you brave yak shaver
 

--- a/lisp/erk.el
+++ b/lisp/erk.el
@@ -11,7 +11,7 @@
 ;; Permission is hereby granted, free of charge, to any person obtaining a copy of
 ;; this software and associated documentation files (the "Software"), to deal in
 ;; the Software without restriction, including without limitation the rights to
-;; use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+;; use, copy, modify, merge, publish, distribute, sub-license, and/or sell copies of
 ;; the Software, and to permit persons to whom the Software is furnished to do so,
 ;; subject to the following conditions:
 
@@ -27,7 +27,7 @@
 
 ;;; Commentary:
 
-;; Set up Emacs package with Gihub repository configuration, complete with
+;; Set up Emacs package with GitHub repository configuration, complete with
 ;; Actions CI, tests, lints, and a licensing scheme all ready to go.  Included
 ;; commands are focused on productivity, appropriate for professional
 ;; development in elisp.  The goal of the package is streamline authoring &
@@ -35,8 +35,8 @@
 ;; scheme, aka opinionated.
 ;;
 ;; The package also uses its own hosted source as a substrate for creating new
-;; packages.  It will clone its source respository and then perform renaming &
-;; relicensing.  Simply call `erk-new' to start a new package.  The
+;; packages.  It will clone its source repository and then perform renaming &
+;; re-licensing.  Simply call `erk-new' to start a new package.  The
 ;; README documents remaining setup steps on GitHub and in preparation for
 ;; publishing on MELPA.
 ;;
@@ -433,7 +433,7 @@ by the author of this repository."
 
 ;;;###autoload
 (defun erk-new (package-name package-prefix clone-root author user-org email &optional rev)
-  "Clone elisp-repo-kit, rename, and relicense in one step.
+  "Clone elisp-repo-kit, rename, and re-license in one step.
 CLONE-ROOT is where you want to clone your package to (including
 the clone dir).  PACKAGE-NAME should be the long name of the
 package, what will show up in melpa etc.  PACKAGE-PREFIX can be


### PR DESCRIPTION
The install nix action appears to have bit-rotted against Github Actions behavior

Additionally, the trigger for PR's was changed to `pull_request_target`.  This was necessary because forks need access to secrets in order to run CI.  You should of course require approval for running CI from forks.  While within an organization, it's common to run CI when a PR is created, for code arriving from untrusted sources, this is in appropriate.  At the least, attacking a repo via PR should require obfuscating the attack within generated expressions that a human will not check.